### PR TITLE
allow disabling the builtin stylesheet

### DIFF
--- a/qa-edh-lang-default.php
+++ b/qa-edh-lang-default.php
@@ -32,6 +32,8 @@ return array(
 	'admin_active_note' => 'Untick to stop tracking post edits.',
 	'admin_ninja' => 'Ninja edit time',
 	'admin_ninja_note' => 'Time (in seconds) between logged edits.',
+	'admin_external_css' => 'Disable plugin stylesheet',
+	'admin_external_css_note' => 'Tick this if you want to use your own CSS instead of the one shipped with this plugin',
 
 	'admin_perms' => 'Edit History visible for',
 	'admin_perms_note' => 'User level allowed to see post revisions.',

--- a/qa-edh-revisions.php
+++ b/qa-edh-revisions.php
@@ -150,6 +150,7 @@ class qa_edh_revisions
 		$this->options = array(
 			'blockwordspreg' => qa_get_block_words_preg(),
 			'fulldatedays' => qa_opt('show_full_date_days'),
+			'external_css' => qa_opt('edit_history_external_css'),
 		);
 		$userids = array();
 
@@ -301,11 +302,13 @@ class qa_edh_revisions
 		// prevent search engines indexing revision pages
 		$qh[] = '<meta name="robots" content="noindex,follow">';
 		// styles for this page
-		$csslines = file_get_contents($this->directory.'revisions.css');
-		$mincss = preg_replace('~\s+~', ' ', $csslines);
-		$qh[] = '<style>';
-		$qh[] = $mincss;
-		$qh[] = '</style>';
+		if (!$this->options['external_css']) {
+			$csslines = file_get_contents($this->directory.'revisions.css');
+			$mincss = preg_replace('~\s+~', ' ', $csslines);
+			$qh[] = '<style>';
+			$qh[] = $mincss;
+			$qh[] = '</style>';
+		}
 
 		$qa_content['script_onloads'][] = array(
 			'$("button[name=revert]").click(function() {',

--- a/qa-edit-history.php
+++ b/qa-edit-history.php
@@ -13,6 +13,7 @@ class qa_edit_history
 	private $opt_ninja = 'edit_history_ninja';
 	private $opt_perms = 'edit_history_view_perms';
 	private $opt_admin = 'edit_history_admin_perms';
+	private $opt_ext_css = 'edit_history_external_css';
 
 	public function option_default($option)
 	{
@@ -21,6 +22,8 @@ class qa_edit_history
 				return 0;
 			case $this->opt_ninja:
 				return 300;
+			case $this->opt_ext_css:
+				return 0;
 			case $this->opt_perms:
 				return QA_PERMIT_USERS;
 			case $this->opt_admin:
@@ -114,6 +117,7 @@ class qa_edit_history
 			qa_opt($this->opt_ninja, qa_post_text('eh_ninja_time'));
 			qa_opt($this->opt_perms, qa_post_text('eh_user_perms'));
 			qa_opt($this->opt_admin, qa_post_text('eh_user_admin'));
+			qa_opt($this->opt_ext_css, qa_post_text('eh_external_css'));
 
 			$saved_msg = qa_lang_html('admin/options_saved');
 		}
@@ -125,6 +129,7 @@ class qa_edit_history
 		// check if options are set
 		$view_perms = qa_opt($this->opt_perms);
 		$admin_perms = qa_opt($this->opt_admin);
+		$external_css = qa_opt($this->opt_ext_css);
 		$sel_perms = isset($permitopts_view[$view_perms]) ? $permitopts_view[$view_perms] : $this->option_default($this->opt_perms);
 		$sel_admin = isset($permitopts_admin[$admin_perms]) ? $permitopts_admin[$admin_perms] : $this->option_default($this->opt_admin);
 
@@ -148,6 +153,14 @@ class qa_edit_history
 					'type' => 'number',
 					'tags' => 'name="eh_ninja_time"',
 					'value' => qa_opt($this->opt_ninja),
+				),
+				// external css
+				array(
+					'label' => qa_lang_html('edithistory/admin_external_css'),
+					'note' => qa_lang_html('edithistory/admin_external_css_note'),
+					'type' => 'checkbox',
+					'tags' => 'name="eh_external_css"',
+					'value' => qa_opt($this->opt_ext_css),
 				),
 				// viewing permissions
 				array(


### PR DESCRIPTION
An option to disable the builtin stylesheet avoids the need to remove the stylesheet from the plugin directory (an action that would need to be repeated with every plugin update).